### PR TITLE
add python3-pip libatlas-base-dev to the installed packages

### DIFF
--- a/Install_not_working.sh
+++ b/Install_not_working.sh
@@ -33,7 +33,7 @@ fi
 
 
 echo "Install python and PyGObject"
-sudo apt-get install -y python3 python3-gi python3-gi-cairo gir1.2-gtk-3.0
+sudo apt-get install -y python3 python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-pip libatlas-base-dev
 
 
 


### PR DESCRIPTION
This change added python3-pip and libatlas-base-dev to the set of installed packages. This was sufficient to allow the installer to work on a clean pi zero (running buster). I noticed that you renamed Install.sh to Install_not_working.sh sometime over the last couple of days. Maybe with this change we can rename it back? :-)

	modified:   Install_not_working.sh