### PR TITLE
Add support for FTMS rower

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ echo "-------------------------------------------------------------"
 echo "updates the list of latest updates available for the packages"
 echo "-------------------------------------------------------------"
 echo " "
-#sudo apt-get update
+sudo apt-get update
 
 echo " "
 echo "----------------------------------------------"
@@ -34,22 +34,22 @@ echo "install needed packages for python          "
 echo "----------------------------------------------"
 echo " "
 
-#sudo apt-get install -y \
-#    python3 \
-#    python3-gi \
-#    python3-gi-cairo \
-#    gir1.2-gtk-3.0 \
-#    python3-pip \
-#    libatlas-base-dev \
-#    libdbus-1-dev \
-#    libglib2.0-dev \
-#    libgirepository1.0-dev \
-#    libcairo2-dev \
-#    zlib1g-dev \
-#    libfreetype6-dev \
-#    liblcms2-dev \
-#    libopenjp2-7 \
-#    libtiff5
+sudo apt-get install -y \
+    python3 \
+    python3-gi \
+    python3-gi-cairo \
+    gir1.2-gtk-3.0 \
+    python3-pip \
+    libatlas-base-dev \
+    libdbus-1-dev \
+    libglib2.0-dev \
+    libgirepository1.0-dev \
+    libcairo2-dev \
+    zlib1g-dev \
+    libfreetype6-dev \
+    liblcms2-dev \
+    libopenjp2-7 \
+    libtiff6
 
 echo " "
 echo "----------------------------------------------"
@@ -57,9 +57,8 @@ echo "set up virtual environment        "
 echo "----------------------------------------------"
 echo " "
 
-#python3 -m venv venv
-#sleep 10
-#source venv/bin/activate
+python3 -m venv venv
+source venv/bin/activate
 
 echo " "
 echo "----------------------------------------------"
@@ -67,8 +66,8 @@ echo "install needed python3 modules for the project        "
 echo "----------------------------------------------"
 echo " "
 
-#pip install --upgrade pip
-#pip install -r requirements.txt
+pip install --upgrade pip
+pip install -r requirements.txt
 
 echo " "
 echo "-------------------------------------------------------"
@@ -171,7 +170,7 @@ echo " setup screen setting to start up at boot                   "
 echo "------------------------------------------------------------"
 echo " "
 
-sudo sed -i 's/#dtparam=spi=on/dtparam=spi=on/g' /boot/config.txt
+sudo sed -i 's/#dtparam=spi=on/dtparam=spi=on/g' /boot/firmware/config.txt
 cp src/adapters/screen/settings.ini.orig src/adapters/screen/settings.ini
 sudo sed -i 's@#REPO_DIR#@'"$repo_dir"'@g' src/adapters/screen/settings.ini
 

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ echo "-------------------------------------------------------------"
 echo "updates the list of latest updates available for the packages"
 echo "-------------------------------------------------------------"
 echo " "
-sudo apt-get update
+#sudo apt-get update
 
 echo " "
 echo "----------------------------------------------"
@@ -34,22 +34,22 @@ echo "install needed packages for python          "
 echo "----------------------------------------------"
 echo " "
 
-sudo apt-get install -y \
-    python3 \
-    python3-gi \
-    python3-gi-cairo \
-    gir1.2-gtk-3.0 \
-    python3-pip \
-    libatlas-base-dev \
-    libdbus-1-dev \
-    libglib2.0-dev \
-    libgirepository1.0-dev \
-    libcairo2-dev \
-    zlib1g-dev \
-    libfreetype6-dev \
-    liblcms2-dev \
-    libopenjp2-7 \
-    libtiff6
+#sudo apt-get install -y \
+#    python3 \
+#    python3-gi \
+#    python3-gi-cairo \
+#    gir1.2-gtk-3.0 \
+#    python3-pip \
+#    libatlas-base-dev \
+#    libdbus-1-dev \
+#    libglib2.0-dev \
+#    libgirepository1.0-dev \
+#    libcairo2-dev \
+#    zlib1g-dev \
+#    libfreetype6-dev \
+#    liblcms2-dev \
+#    libopenjp2-7 \
+#    libtiff5
 
 echo " "
 echo "----------------------------------------------"
@@ -57,8 +57,9 @@ echo "set up virtual environment        "
 echo "----------------------------------------------"
 echo " "
 
-python3 -m venv venv
-source venv/bin/activate
+#python3 -m venv venv
+#sleep 10
+#source venv/bin/activate
 
 echo " "
 echo "----------------------------------------------"
@@ -66,8 +67,8 @@ echo "install needed python3 modules for the project        "
 echo "----------------------------------------------"
 echo " "
 
-pip install --upgrade pip
-pip install -r requirements.txt
+#pip install --upgrade pip
+#pip install -r requirements.txt
 
 echo " "
 echo "-------------------------------------------------------"
@@ -170,7 +171,7 @@ echo " setup screen setting to start up at boot                   "
 echo "------------------------------------------------------------"
 echo " "
 
-sudo sed -i 's/#dtparam=spi=on/dtparam=spi=on/g' /boot/firmware/config.txt
+sudo sed -i 's/#dtparam=spi=on/dtparam=spi=on/g' /boot/config.txt
 cp src/adapters/screen/settings.ini.orig src/adapters/screen/settings.ini
 sudo sed -i 's@#REPO_DIR#@'"$repo_dir"'@g' src/adapters/screen/settings.ini
 

--- a/src/adapters/ftmsrower/ftmsrowerreader.py
+++ b/src/adapters/ftmsrower/ftmsrowerreader.py
@@ -1,0 +1,144 @@
+import gatt
+import logging
+import threading
+from time import time
+
+logger = logging.getLogger(__name__)
+
+#This SDK requires you to create subclasses of gatt.DeviceManager and gatt.Device. The other two classes gatt.Service and gatt.Characteristic are not supposed to be subclassed.
+
+#The SDK entry point is the DeviceManager class. Check the following example to dicover any Bluetooth Low Energy device nearby.
+
+
+class FTMS_Rower(gatt.Device):
+
+    SERVICE_UUID_FTMSROWER = "00001826-0000-1000-8000-00805f9b34fb"
+    CHARACTERISTIC_UUID_ROWWRITE = "00002ad9-0000-1000-8000-00805f9b34fb"
+    CHARACTERISTIC_UUID_ROWDATA = "00002ad1-0000-1000-8000-00805f9b34fb"
+
+    def __init__(self, mac_address, manager):
+        super().__init__(mac_address=mac_address, manager=manager)
+        self._callbacks = set()
+        self.lock = threading.Lock()
+        self.is_connected = False
+
+    def ready(self):
+      with self.lock: #"Lock Acquired"
+          return self.is_connected
+      
+    def connect_succeeded(self):
+        super().connect_succeeded()
+        logger.info("Connected to [{}]".format(self.mac_address))
+
+
+    def connect_failed(self, error):
+        super().connect_failed(error)
+        logger.info("Connection failed [{}]: {}".format(self.mac_address, error))
+
+    def disconnect_succeeded(self):
+        super().disconnect_succeeded()
+        logger.info("Disconnected [{}]".format(self.mac_address))
+        #self.connect()
+
+    def find_service(self, uuid):
+        for service in self.services:
+            if service.uuid == uuid:
+                return service
+
+        return None
+
+    def find_characteristic(self, service, uuid):
+        for chrstc in service.characteristics:
+            if chrstc.uuid == uuid:
+                return chrstc
+
+        return None
+
+    def services_resolved(self):
+        super().services_resolved()
+
+        logger.info("Resolved services [{}]".format(self.mac_address))
+        for service in self.services:
+            logger.info("\t[{}] Service [{}]".format(self.mac_address, service.uuid))
+            for characteristic in service.characteristics:
+                logger.info("\t\tCharacteristic [{}]".format(characteristic.uuid))
+
+        self.serviceFTMS_Rower = self.find_service(self.SERVICE_UUID_FTMSROWER)
+        self.chrstcRowData = self.find_characteristic(self.serviceFTMS_Rower, self.CHARACTERISTIC_UUID_ROWDATA)
+        self.chrstcRowData.enable_notifications()
+
+        self.chrstcRowWrite = self.find_characteristic(self.serviceFTMS_Rower, self.CHARACTERISTIC_UUID_ROWWRITE)
+        with self.lock: #"Lock Acquired"
+            self.is_connected = True
+        
+    def characteristic_value_updated(self, characteristic, value):
+        super().characteristic_value_updated(characteristic, value)
+        #self.buffer = value.decode()
+        self.notify_callbacks(value)
+
+
+    def characteristic_write_value(self, value):
+        self.writing = value
+        #print(value)
+        self.chrstcRowWrite.write_value(value)
+
+    def register_callback(self, cb):
+        self._callbacks.add(cb)
+
+    def remove_callback(self, cb):
+        self._callbacks.remove(cb)
+
+    def notify_callbacks(self, event):
+        for cb in self._callbacks:
+            cb(event)
+
+class FTMS_Row_Manager(gatt.DeviceManager):
+    def __init__(self,*args,**kwargs):
+        gatt.DeviceManager.__init__(self, *args, **kwargs)
+        self.lock = threading.Lock()
+        self.discovered=False 
+
+    def ready(self):
+        with self.lock:
+            return self.discovered
+        
+    def device_discovered(self, device):
+        # Better to allow an argument for the FTMS device alias?
+        if device.alias() == "CR 71":
+            logging.info("found FTMS Rower")
+            logging.info(device.mac_address)
+            self.ftmsrowmac = device.mac_address
+            self.stop()
+            with self.lock: #"Lock Acquired"
+                self.discovered=True
+
+
+def connecttoftmsrow():
+    manager = FTMS_Row_Manager(adapter_name='hci0')
+    logger.info("starting discovery")
+    manager.start_discovery()  # from the DeviceManager class call the methode start_discorvery
+    manager.run()
+    while not manager.ready(): # hold the thread locked a checks if FTMS Rower has been found. Then gives other process 0.2 sec time to work
+        time.sleep(0.2)
+    logger.info("found FTMS Row macaddress")
+    macaddressftmsrower = manager.ftmsrowmac    
+    return macaddressftmsrower
+
+
+if __name__ == '__main__':
+
+    manager = gatt.DeviceManager(adapter_name='hci0')
+    device = FTMS_Rower(mac_address="", manager=manager)
+    device.connect()
+
+    manager.run()
+
+    # manager = FTMS_Row_ManagerRowManager(adapter_name='hci0')
+    # manager.start_discovery()
+    # try:
+    #     manager.run()
+    # except KeyboardInterrupt:
+    #     for device in manager.devices():
+    #         if device.is_connected():
+    #             device.disconnect()
+    #     manager.stop()

--- a/src/adapters/ftmsrower/ftmsrowtobleant.py
+++ b/src/adapters/ftmsrower/ftmsrowtobleant.py
@@ -20,7 +20,7 @@ class DataLogger():
     #        |  +--+- Total Strokes
     #        |  |  |  +--+--+- Total Distance
     #        |  |  |  |  |  |  +--+- Instantaneous Pace
-    #        |  |  |  |  |  |  |  |  +--+- Instanteous Power
+    #        |  |  |  |  |  |  |  |  +--+- Instantaneous Power (watts)
     #        |  |  |  |  |  |  |  |  |  |  +--+- Total Energy
     #        |  |  |  |  |  |  |  |  |  |  |  |  +--+- Energy_per_hour
     #        |  |  |  |  |  |  |  |  |  |  |  |  |  |  +- Energy Per Minute
@@ -118,8 +118,8 @@ class DataLogger():
             self.elapsedtime()
 
             print(self.WRValues)
-            print("| H|R| TS|   TD| IP| Wa| TE| TH|M|time")
-            print(event.hex())
+            #print("| H|R| TS|   TD| IP| Wa| TE| TH|M|time")
+            #print(event.hex())
 
 
 def connectFTMS(manager,ftms):

--- a/src/adapters/ftmsrower/ftmsrowtobleant.py
+++ b/src/adapters/ftmsrower/ftmsrowtobleant.py
@@ -16,7 +16,7 @@ class DataLogger():
     # INDEXES are [index, length]
     # referencing later by [index:index + length] notation
     # All little endian?
-    #        +- Strokes per 1/2 second
+    #        +- Strokes per 2 seconds
     #        |  +--+- Total Strokes
     #        |  |  |  +--+--+- Total Distance
     #        |  |  |  |  |  |  +--+- Instantaneous Pace

--- a/src/adapters/ftmsrower/ftmsrowtobleant.py
+++ b/src/adapters/ftmsrower/ftmsrowtobleant.py
@@ -1,0 +1,184 @@
+import logging
+import struct
+
+import gatt
+import threading
+from time import sleep
+import time
+from copy import deepcopy
+
+from . import ftmsrowerreader
+
+logger = logging.getLogger(__name__)
+
+
+class DataLogger():
+    # INDEXES are [index, length]
+    # referencing later by [index:index + length] notation
+    # All little endian?
+    #        +- Strokes per 1/2 second
+    #        |  +--+- Total Strokes
+    #        |  |  |  +--+--+- Total Distance
+    #        |  |  |  |  |  |  +--+- Instantaneous Pace
+    #        |  |  |  |  |  |  |  |  +--+- Instanteous Power
+    #        |  |  |  |  |  |  |  |  |  |  +--+- Total Energy
+    #        |  |  |  |  |  |  |  |  |  |  |  |  +--+- Energy_per_hour
+    #        |  |  |  |  |  |  |  |  |  |  |  |  |  |  +- Energy Per Minute
+    #        |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  +--+- Elapsed time
+    #        |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+    #  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 Index
+    # 2c-09-32-03-00-2b-00-00-95-00-83-00-09-00-f1-02-00-12-00
+    INDEXES = {
+    "stroke_rate": [2, 1], # /2 for StrokesPerSecond
+    "total_strokes": [3, 2], # Total, 02 00 = 00 02 = 2
+    "total_distance_m": [5, 3], # Total, Meters 1a 00 00 = 00 00 1a = 26
+    "instantaneous pace": [8, 2], # Gauge, c4 00 = 00 c4 = 196 seconds per 500 meters
+    "watts": [10, 2], # Gauge, 50 00 = 00 50 = 80 watts (instantaneous_power)
+    "total_kcal": [12, 2], # Total, kCal 07 00 = 00 07 = 7 kCal
+    "total_kcal_hour": [14, 2], # Gauge? Total? Total if we continue for 1 hr? 
+    "total_kcal_minute": [16, 1], # Gauge/Avg, once at least a minute is done
+    #"elapsed_time": [17, 3], # Total reported, but apparently we calculate it?
+    }
+    FTMS_EVENT = 44
+    
+    def __init__(self, rower_interface):
+        self._rower_interface = rower_interface
+        self._rower_interface.register_callback(self.on_row_event)
+        
+        self.WRValues_rst = None
+        self.WRValues = None
+        self.WRValues_standstill = None
+        self.starttime = None
+        self.fullstop = None
+        self.ftmsHalt = None
+        
+        self._reset_state()
+    
+    def _reset_state(self):
+        self.WRValues_rst = {
+        'stroke_rate': 0,
+        'total_strokes': 0,
+        'total_distance_m': 0,
+        'instantaneous pace': 0,
+        'speed': 0,
+        'watts': 0,
+        'total_kcal': 0,
+        'total_kcal_hour': 0,
+        'total_kcal_min': 0,
+        'heart_rate': 0,
+        'elapsedtime': 0.0,
+        'work': 0,
+        'stroke_length': 0,
+        'force': 0,
+        'watts_avg':0,
+        'pace_avg':0
+        }
+        self.WRValues = deepcopy(self.WRValues_rst)
+        self.WRValues_standstill = deepcopy(self.WRValues_rst)
+        self.starttime = None # time.time() # was None
+        self.fullstop = True
+        self.ftmsHalt = False
+        self.Initial_reset = False
+    
+    
+    def elapsedtime(self):
+        print(self.fullstop)
+        if self.fullstop == False:
+            elaspedtimecalc = int(time.time() - self.starttime)
+            self.WRValues.update({'elapsedtime':elaspedtimecalc})
+        elif self.fullstop == True and self.WRValues.get('total_distance_m') !=0 and self.Initial_reset == True:
+            if not self.starttime:
+                self.starttime = time.time()
+            elaspedtimecalc = int(time.time() - self.starttime)
+            self.WRValues.update({'elapsedtime':elaspedtimecalc})
+        else:
+            self.WRValues.update({'elapsedtime': 0})
+
+    def on_row_event(self, event):
+        if int(event[0]) == self.FTMS_EVENT:
+            oldWRValues = deepcopy(self.WRValues)
+            for message_type, indexes in self.INDEXES.items():
+                i, l = indexes
+                # Get the data at the index(es), reverse the byte order
+                # Convert the bytestring to a hex string, then to a decimal integer
+                integer_value = int(event[i:i+l][::-1].hex(),16)
+                #if message_type = "stroke_rate":
+                #    integer_value = int(integer_value / 2) # Handled in antfe.py
+                self.WRValues.update({message_type: integer_value})
+                if message_type == "instantaneous pace" and integer_value > 0:
+                    # pace is seconds per 500m
+                    # We want cm/s? I guess? So 500 (meters) * 100 gives us CM
+                    # Then divide by pace for cm/s
+                    speed = 500 * 100 / integer_value
+                    self.WRValues.update({'speed': speed})
+            new_strokes = self.WRValues['total_strokes'] - oldWRValues['total_strokes']
+            new_distance = self.WRValues['total_distance_m'] - oldWRValues['total_distance_m']
+            if new_strokes > 0:
+                self.WRValues.update({'stroke_length':  new_distance / new_strokes})
+            self.elapsedtime()
+
+            print(self.WRValues)
+            print("| H|R| TS|   TD| IP| Wa| TE| TH|M|time")
+            print(event.hex())
+
+
+def connectFTMS(manager,ftms):
+    ftms.connect()
+    manager.run()
+
+def reset(ftms):
+    pass
+    ftms.characteristic_write_value(struct.pack("<b", 13))
+    sleep(0.002)
+    ftms.characteristic_write_value(struct.pack("<b", 86))
+    sleep(0.002)
+    ftms.characteristic_write_value(struct.pack("<b", 64))
+    sleep(0.002)
+    ftms.characteristic_write_value(struct.pack("<b", 13))
+
+def heartbeat(sr):
+    pass
+    while True:
+        sr.characteristic_write_value(struct.pack("<b", 36))
+        sleep(1)
+
+
+def main(in_q, ble_out_q,ant_out_q):
+    # this starts discovery, calls manager.run() and returns manager.ftmsmac
+    # 
+    macaddressftms = ftmsrowerreader.connecttoftmsrow()
+    manager = gatt.DeviceManager(adapter_name='hci0')
+    ftms = ftmsrowerreader.FTMS_Rower(mac_address=macaddressftms, manager=manager)
+    FTMStoBLEANT = DataLogger(ftms)
+    
+    BC = threading.Thread(target=connectFTMS, args=(manager,ftms))
+    BC.daemon = True
+    BC.start()
+
+    logger.info("FTMSRower Ready and sending data to BLE and ANT Thread")
+    while not ftms.ready() :
+        sleep(0.2)
+
+    print("starting heart beat")
+    HB = threading.Thread(target=heartbeat, args=([ftms]))
+    HB.daemon = True
+    HB.start()
+    sleep(3) # this sleep is needed in order give the user time to putt back the handle after pulling it to activate it.
+    # The ftms device is very sensitive to touches which then triggers 1 m very easy after a reset which then already starts after a restart.
+    reset(ftms)
+    sleep(1)
+    FTMStoBLEANT.Initial_reset = True # this should help to check if the first reset has been performed
+
+    while True:
+        if not in_q.empty():
+            ResetRequest_ble = in_q.get()
+            print(ResetRequest_ble)
+            reset(ftms)
+        else:
+            pass
+        ble_out_q.append(FTMStoBLEANT.WRValues)
+        ant_out_q.append(FTMStoBLEANT.WRValues)
+        sleep(0.1)
+
+if __name__ == '__main__':
+    main()

--- a/src/adapters/smartrow/smartrowtobleant.py
+++ b/src/adapters/smartrow/smartrowtobleant.py
@@ -14,68 +14,68 @@ logger = logging.getLogger(__name__)
 
 class DataLogger():
 
-ENERGIE_KCAL_MESSAGE = "a"
-WORK_STROKE_LENGTH_MESSAGE = "b"
-POWER_MESSAGE = "c"
-STROKE_RATE_STROKE_COUNT_MESSAGE = "d"
-PACE_MESSAGE = "e"
-FORCE_MESSAGE = "f"
-FIRST_PART_FORCE_CURVE_MESSAGE = "x"
-SECOND_PART_FORCE_CURVE_MESSAGE = "y"
-THIRD_PARD_FORCE_CURVE_MESSAGE = "z"
+    ENERGIE_KCAL_MESSAGE = "a"
+    WORK_STROKE_LENGTH_MESSAGE = "b"
+    POWER_MESSAGE = "c"
+    STROKE_RATE_STROKE_COUNT_MESSAGE = "d"
+    PACE_MESSAGE = "e"
+    FORCE_MESSAGE = "f"
+    FIRST_PART_FORCE_CURVE_MESSAGE = "x"
+    SECOND_PART_FORCE_CURVE_MESSAGE = "y"
+    THIRD_PARD_FORCE_CURVE_MESSAGE = "z"
 
-def __init__(self, rower_interface):
-self._rower_interface = rower_interface
-self._rower_interface.register_callback(self.on_row_event)
-
-self.WRValues_rst = None
-self.WRValues = None
-self.WRValues_standstill = None
-self.starttime = None
-self.fullstop = None
-self.SmartRowHalt = None
-
-self._reset_state()
-
-def _reset_state(self):
-self.WRValues_rst = {
-'stroke_rate': 0,
-'total_strokes': 0,
-'total_distance_m': 0,
-'instantaneous pace': 0,
-'speed': 0,
-'watts': 0,
-'total_kcal': 0,
-'total_kcal_hour': 0,
-'total_kcal_min': 0,
-'heart_rate': 0,
-'elapsedtime': 0.0,
-'work': 0,
-'stroke_length': 0,
-'force': 0,
-'watts_avg':0,
-'pace_avg':0
-}
-self.WRValues = deepcopy(self.WRValues_rst)
-self.WRValues_standstill = deepcopy(self.WRValues_rst)
-self.starttime = None # time.time() # was None
-self.fullstop = True
-self.SmartRowHalt = False
-self.Initial_reset = False
-
-
-def elapsedtime(self):
-print(self.fullstop)
-if self.fullstop == False:
-elaspedtimecalc = int(time.time() - self.starttime)
-self.WRValues.update({'elapsedtime':elaspedtimecalc})
-elif self.fullstop == True and self.WRValues.get('total_distance_m') !=0 and self.Initial_reset == True:
-if not self.starttime:
-self.starttime = time.time()
-elaspedtimecalc = int(time.time() - self.starttime)
-self.WRValues.update({'elapsedtime':elaspedtimecalc})
-else:
-self.WRValues.update({'elapsedtime': 0})
+    def __init__(self, rower_interface):
+        self._rower_interface = rower_interface
+        self._rower_interface.register_callback(self.on_row_event)
+        
+        self.WRValues_rst = None
+        self.WRValues = None
+        self.WRValues_standstill = None
+        self.starttime = None
+        self.fullstop = None
+        self.SmartRowHalt = None
+        
+        self._reset_state()
+    
+    def _reset_state(self):
+        self.WRValues_rst = {
+        'stroke_rate': 0,
+        'total_strokes': 0,
+        'total_distance_m': 0,
+        'instantaneous pace': 0,
+        'speed': 0,
+        'watts': 0,
+        'total_kcal': 0,
+        'total_kcal_hour': 0,
+        'total_kcal_min': 0,
+        'heart_rate': 0,
+        'elapsedtime': 0.0,
+        'work': 0,
+        'stroke_length': 0,
+        'force': 0,
+        'watts_avg':0,
+        'pace_avg':0
+        }
+        self.WRValues = deepcopy(self.WRValues_rst)
+        self.WRValues_standstill = deepcopy(self.WRValues_rst)
+        self.starttime = None # time.time() # was None
+        self.fullstop = True
+        self.SmartRowHalt = False
+        self.Initial_reset = False
+    
+    
+    def elapsedtime(self):
+        print(self.fullstop)
+        if self.fullstop == False:
+            elaspedtimecalc = int(time.time() - self.starttime)
+            self.WRValues.update({'elapsedtime':elaspedtimecalc})
+        elif self.fullstop == True and self.WRValues.get('total_distance_m') !=0 and self.Initial_reset == True:
+            if not self.starttime:
+                self.starttime = time.time()
+            elaspedtimecalc = int(time.time() - self.starttime)
+            self.WRValues.update({'elapsedtime':elaspedtimecalc})
+        else:
+            self.WRValues.update({'elapsedtime': 0})
 
     def on_row_event(self, event):
         if event[0] == self.ENERGIE_KCAL_MESSAGE:
@@ -124,11 +124,11 @@ self.WRValues.update({'elapsedtime': 0})
             if pace_inst != 0:
                 speed = int(500 * 100 / pace_inst) # speed in cm/s
                 self.WRValues.update({'speed': speed})
-else:
+            else:
                 self.WRValues.update({'speed': 0})
-            pace_avg = int(event[9])*60 + int(event[10:12])
-            self.WRValues.update({'pace_avg': pace_avg})
-            self.elapsedtime()
+                pace_avg = int(event[9])*60 + int(event[10:12])
+                self.WRValues.update({'pace_avg': pace_avg})
+                self.elapsedtime()
 
         if event[0] == self.FORCE_MESSAGE:
             event = event.replace(" ", "0")
@@ -141,69 +141,69 @@ else:
                 self.starttime = time.time()
                 self.SmartRowHalt = False
                 self.fullstop = False
-else:
+            else:
                 self.SmartRowHalt = False
                 self.fullstop = False
             self.elapsedtime()
 
-print(self.WRValues)
+            print(self.WRValues)
 
 
 def connectSR(manager,smartrow):
-smartrow.connect()
-manager.run()
+    smartrow.connect()
+    manager.run()
 
 def reset(smartrow):
-smartrow.characteristic_write_value(struct.pack("<b", 13))
-sleep(0.002)
-smartrow.characteristic_write_value(struct.pack("<b", 86))
-sleep(0.002)
-smartrow.characteristic_write_value(struct.pack("<b", 64))
-sleep(0.002)
-smartrow.characteristic_write_value(struct.pack("<b", 13))
+    smartrow.characteristic_write_value(struct.pack("<b", 13))
+    sleep(0.002)
+    smartrow.characteristic_write_value(struct.pack("<b", 86))
+    sleep(0.002)
+    smartrow.characteristic_write_value(struct.pack("<b", 64))
+    sleep(0.002)
+    smartrow.characteristic_write_value(struct.pack("<b", 13))
 
 def heartbeat(sr):
-while True:
-sr.characteristic_write_value(struct.pack("<b", 36))
-sleep(1)
+    while True:
+        sr.characteristic_write_value(struct.pack("<b", 36))
+        sleep(1)
 
 
 def main(in_q, ble_out_q,ant_out_q):
-# this starts discovery, calls manager.run() and returns manager.smartrowmac
-# 
-macaddresssmartrower = smartrowreader.connecttosmartrow()
-manager = gatt.DeviceManager(adapter_name='hci0')
-smartrow = smartrowreader.SmartRow(mac_address=macaddresssmartrower, manager=manager)
-SRtoBLEANT = DataLogger(smartrow)
+    # this starts discovery, calls manager.run() and returns manager.smartrowmac
+    # 
+    macaddresssmartrower = smartrowreader.connecttosmartrow()
+    manager = gatt.DeviceManager(adapter_name='hci0')
+    smartrow = smartrowreader.SmartRow(mac_address=macaddresssmartrower, manager=manager)
+    SRtoBLEANT = DataLogger(smartrow)
+    
+    BC = threading.Thread(target=connectSR, args=(manager,smartrow))
+    BC.daemon = True
+    BC.start()
 
-BC = threading.Thread(target=connectSR, args=(manager,smartrow))
-BC.daemon = True
-BC.start()
+    logger.info("SmartRow Ready and sending data to BLE and ANT Thread")
+    while not smartrow.ready() :
+        sleep(0.2)
 
-logger.info("SmartRow Ready and sending data to BLE and ANT Thread")
-while not smartrow.ready() :
-sleep(0.2)
+    print("starting heart beat")
+    HB = threading.Thread(target=heartbeat, args=([smartrow]))
+    HB.daemon = True
+    HB.start()
+    sleep(3) # this sleep is needed in order give the user time to putt back the handle after pulling it to activate it.
+    # The SmartRow device is very sensitive to touches which then triggers 1 m very easy after a reset which then already starts after a restart.
+    reset(smartrow)
+    sleep(1)
+    SRtoBLEANT.Initial_reset = True # this should help to check if the first reset has been performed
 
-print("starting heart beat")
-HB = threading.Thread(target=heartbeat, args=([smartrow]))
-HB.daemon = True
-HB.start()
-sleep(3) # this sleep is needed in order give the user time to putt back the handle after pulling it to activate it.
-# The SmartRow device is very sensitive to touches which then triggers 1 m very easy after a reset which then already starts after a restart.
-reset(smartrow)
-sleep(1)
-SRtoBLEANT.Initial_reset = True # this should help to check if the first reset has been performed
-
-while True:
-if not in_q.empty():
-ResetRequest_ble = in_q.get()
-print(ResetRequest_ble)
-reset(smartrow)
-else:
-pass
-ble_out_q.append(SRtoBLEANT.WRValues)
-ant_out_q.append(SRtoBLEANT.WRValues)
-sleep(0.1)
+    while True:
+        if not in_q.empty():
+            ResetRequest_ble = in_q.get()
+            print(ResetRequest_ble)
+            reset(smartrow)
+        else:
+            pass
+        ble_out_q.append(SRtoBLEANT.WRValues)
+        ant_out_q.append(SRtoBLEANT.WRValues)
+        sleep(0.1)
 
 if __name__ == '__main__':
-main()
+    main()

--- a/src/waterrowerthreads.py
+++ b/src/waterrowerthreads.py
@@ -146,7 +146,7 @@ def main(args=None):
 if __name__ == '__main__':
     try:
         parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter, )
-        parser.add_argument("-i", "--interface", choices=["ftms","s4","sr"], default="s4", help="choose  Waterrower interface S4 monitor: s4 or Smartrow: sr or Cityrow: cr")
+        parser.add_argument("-i", "--interface", choices=["ftms","s4","sr"], default="s4", help="choose  Waterrower interface S4 monitor: s4 or Smartrow: sr or FTMS Rower: ftms")
         parser.add_argument("-b", "--blue", action='store_true', default=False,help="Broadcast Waterrower data over bluetooth low energy")
         parser.add_argument("-a", "--antfe", action='store_true', default=False,help="Broadcast Waterrower data over Ant+")
         args = parser.parse_args()

--- a/src/waterrowerthreads.py
+++ b/src/waterrowerthreads.py
@@ -32,6 +32,7 @@ from adapters.ble import waterrowerble
 from adapters.s4 import wrtobleant
 from adapters.ant import waterrowerant
 from adapters.smartrow import smartrowtobleant
+from adapters.ftmsrower import ftmsrowtobleant
 import pathlib
 import signal
 
@@ -76,6 +77,11 @@ def main(args=None):
         Smartrowconnection = smartrowtobleant.main(in_q, ble_out_q, ant_out_q)
         Smartrowconnection()
 
+    def FTMSrower(in_q, ble_out_q, ant_out_q):
+        logger.info("FTMS Rower Interface started")
+        ftms_row_conn = ftmsrowtobleant.main(in_q, ble_out_q, ant_out_q)
+        ftms_row_conn()
+
     def ANTService(in_q, ant_in_q):
         logger.info("Start Ant and start broadcast data")
         antService = waterrowerant.main(in_q, ant_in_q)
@@ -105,6 +111,15 @@ def main(args=None):
     else:
         logger.info("sr not selected")
 
+    if args.interface == "ftms":
+        logger.info("interface ftms will be used for data input")
+        t = threading.Thread(target=FTMS_rower, args=(q, ble_q, ant_q))
+        t.daemon = True
+        t.start()
+        threads.append(t)
+    else:
+        logger.info("ftms (cityrow) not selected")
+
     if args.blue == True:
         t = threading.Thread(target=BleService, args=(q, ble_q))
         t.daemon = True
@@ -131,7 +146,7 @@ def main(args=None):
 if __name__ == '__main__':
     try:
         parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter, )
-        parser.add_argument("-i", "--interface", choices=["s4","sr"], default="s4", help="choose  Waterrower interface S4 monitor: s4 or Smartrow: sr")
+        parser.add_argument("-i", "--interface", choices=["ftms","s4","sr"], default="s4", help="choose  Waterrower interface S4 monitor: s4 or Smartrow: sr or Cityrow: cr")
         parser.add_argument("-b", "--blue", action='store_true', default=False,help="Broadcast Waterrower data over bluetooth low energy")
         parser.add_argument("-a", "--antfe", action='store_true', default=False,help="Broadcast Waterrower data over Ant+")
         args = parser.parse_args()

--- a/src/waterrowerthreads.py
+++ b/src/waterrowerthreads.py
@@ -113,7 +113,7 @@ def main(args=None):
 
     if args.interface == "ftms":
         logger.info("interface ftms will be used for data input")
-        t = threading.Thread(target=FTMS_rower, args=(q, ble_q, ant_q))
+        t = threading.Thread(target=FTMSrower, args=(q, ble_q, ant_q))
         t.daemon = True
         t.start()
         threads.append(t)


### PR DESCRIPTION
Tested with:
WaterRower CityRow Go (2021?, no integrated display)
raspberry pi 4 w/ Dynastream Innovations, Inc. ANTUSB2 Stick
Garmin Epix Gen 2 smartwatch

The Epix Gen 2 smartwatch, and theoretically many other Garmin smartwatches, can receive stroke rate/total strokes/distance/power/etc. from an ANT+ FE-C rower, but NOT from a BLE FTMS Rower. The CityRow rower broadcasts using the BLE FTMS profile, but not ANT+.

Hopefully this will work with additional rowers which use the BLE FTMS profile, such as the newer WaterRower S4 modules with integrated Bluetooth.

The smartrow adapter was the starting point for the ftms adapter. However the "reset" function has been changed to a pass, as I haven't determined if it is necessary with an FTMS compliant rower, nor how to properly reset an FTMS rower. Skipping the reset doesn't seem to cause any negative impact in my tests. I also set heartbeat to pass, rather than writing to the FTMS profile with data that might not be relevant to, or properly formatted for, that profile.